### PR TITLE
Typeahead: allow ideographic whitespace for token separation

### DIFF
--- a/src/lib/control/typeahead/source/TypeaheadSource.js
+++ b/src/lib/control/typeahead/source/TypeaheadSource.js
@@ -262,7 +262,7 @@ JX.install('TypeaheadSource', {
       if (!str.length) {
         return [];
       }
-      return str.split(/ /g);
+      return str.split(/\s/g);
     },
     _defaultTransformer : function(object) {
       return {


### PR DESCRIPTION
Summary:Allow ideographic whitespace for token separation. This allows users to search for names in CJK languages without switching input modes between words, if searching for multiple tokens.

  児玉 太郎 // worked previously, still works now
  児玉　太郎 // works now, didn't work previously

Reviewers:epriestley

Test Plan:tried searching via typeahead using ' ' (ascii 32) and using ideographic whitespace (U+3000) to separate search tokens. got results for both.

Revert Plan:

Tags:
