### PR TITLE
[javelinsymbols] -- Add support to javelinsymbols for JX.behavior()

### DIFF
--- a/support/javelinsymbols/javelinsymbols.cpp
+++ b/support/javelinsymbols/javelinsymbols.cpp
@@ -17,31 +17,39 @@ typedef map<string, int> symbol_t;
 
 string get_static_member_symbol(Node *node);
 
-void find_symbols(Node *node, symbol_t &installs, symbol_t &uses) {
+void find_symbols(Node *node, symbol_t &installs, symbol_t &behaviors,
+                  symbol_t &uses) {
   if (node == NULL) {
     return;
   }
-  
+
   if (typeid(*node) == typeid(NodeStaticMemberExpression)) {
     string symbol = get_static_member_symbol(node);
     if (symbol[0] == 'J' && symbol[1] == 'X' && symbol[2] == '.') {
       uses[symbol] = node->lineno();
     }
   }
-  
+
   if (typeid(*node) == typeid(NodeFunctionCall)) {
     Node *call = *node->childNodes().begin();
     if (static_cast<NodeStaticMemberExpression *>(call)) {
-      if (get_static_member_symbol(call) == "JX.install") {
-        NodeArgList *args = static_cast<NodeArgList*>(*(++node->childNodes().begin()));
-        NodeStringLiteral* lit = static_cast<NodeStringLiteral*>(*args->childNodes().begin());
-        installs[lit->unquoted_value()] = node->lineno();
+      string symbol = get_static_member_symbol(call);
+      if (symbol == "JX.install" || symbol == "JX.behavior") {
+        NodeArgList *args =
+          static_cast<NodeArgList*>(*(++node->childNodes().begin()));
+        NodeStringLiteral* lit =
+          static_cast<NodeStringLiteral*>(*args->childNodes().begin());
+        if (symbol == "JX.install") {
+          installs[lit->unquoted_value()] = node->lineno();
+        } else {
+          behaviors[lit->unquoted_value()] = node->lineno();
+        }
       }
     }
   }
-  
+
   for_nodes(node, ii) {
-    find_symbols(*ii, installs, uses);
+    find_symbols(*ii, installs, behaviors, uses);
   }
 }
 
@@ -65,26 +73,30 @@ string get_static_member_symbol(Node *node) {
       symbol += get_static_member_symbol(*ii);
     }
   }
-  
+
   return symbol;
 }
 
 int main(int argc, char* argv[]) {
   try {
     NodeProgram root(stdin); // parses
-    
+
     symbol_t installs;
+    symbol_t behaviors;
     symbol_t uses;
-    
-    find_symbols(&root, installs, uses);
-    
+
+    find_symbols(&root, installs, behaviors, uses);
+
     for (symbol_t::iterator ii = installs.begin(); ii != installs.end(); ++ii) {
       cout << "+" << ii->first << ":" << ii->second << endl;
+    }
+    for (symbol_t::iterator ii = behaviors.begin(); ii != behaviors.end(); ++ii) {
+      cout << "*" << ii->first << ":" << ii->second << endl;
     }
     for (symbol_t::iterator ii = uses.begin(); ii != uses.end(); ++ii) {
       cout << "?" << ii->first << ":" << ii->second << endl;
     }
-    
+
   } catch (ParseException ex) {
     printf("Parse Error: %s\n", ex.what());
     return 1;


### PR DESCRIPTION
Summary:
Currently javelinsymbols can detect the installation of a class...but not behaviors. This adds support to the javelinsymbols processor to identify behavior-registrations and specify them using a new '*' directive.

I plan to use javelinsymbols for a project to implicitly identify a unique name for a given JS resource based on the JX.install()s and JX.behavior()s calls that exist in the file.

Test Plan: Compiled and ran javlinesymbols against a file with a JX.install(), a file with JX.behavior(), and a file with both to verify the output was as expected.

Reviewers: leebyron, epriestley, jg

Reviewed By: epriestley

CC: aran, epriestley

Differential Revision: https://secure.phabricator.com/D2023
