### PR TITLE
include input elements w/ type="tel" or "number" when encoding form value

### DIFF
--- a/src/lib/DOM.js
+++ b/src/lib/DOM.js
@@ -536,7 +536,8 @@ JX.install('DOM', {
         var type = elements[ii].type;
         var tag  = elements[ii].tagName;
         if ((type in {radio: 1, checkbox: 1} && elements[ii].checked) ||
-             type in {text: 1, hidden: 1, password: 1, email: 1} ||
+             type in {text: 1, hidden: 1, password: 1, email: 1, tel: 1,
+                      number: 1} ||
              tag in {TEXTAREA: 1, SELECT: 1}) {
           data.push([elements[ii].name, elements[ii].value]);
         }


### PR DESCRIPTION
Summary: Right now JX.DOM.convertFormToDictionary will skip over input
elements with type="tel" (or type="number"), which are valid values for
that attribute according to http://dev.w3.org/html5/markup/input.number.html
and http://dev.w3.org/html5/markup/input.tel.html.

This makes convertFormToListOfPairs include those input elements.

Test Plan: used in subsequent change which uses input type="tel" in
conjunction with JX.DOM.convertFormToDictionary.
