### PR TITLE
Optimizing JX.Keys with native Object.Keys if available

### DIFF
--- a/src/core/util.js
+++ b/src/core/util.js
@@ -275,7 +275,7 @@ JX.bag = function() {
  *
  * @group util
  */
-JX.keys = function(obj) {
+JX.keys = Object.keys || function(obj) {
   var r = [];
   for (var k in obj) {
     r.push(k);


### PR DESCRIPTION
Defaulting to Object.Keys for JX.Keys if its available. 

https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/keys

Also, JX.Keys should typically only return enumerable keys. Currently, usage of for-in causes it to enumerate prototype chain properties too.
