### PR TITLE
Sends a X-Requested-With header

### DIFF
--- a/src/lib/Request.js
+++ b/src/lib/Request.js
@@ -156,6 +156,10 @@ JX.install('Request', {
         return;
       }
 
+      //Sets the X-Requested-With header to be compliant with other 
+      //libraries and frameworks.
+      xport.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
+
       if (method == 'POST') {
         if (this.getFile()) {
           xport.send(this.getFile());


### PR DESCRIPTION
Many Javascript frameworks sends the "X-Requested-With: XMLHttpRequest" header with their ajax requests. It mainly allows server side frameworks to detect ajax requests. It would be great for interoperability to have Javelin send this header too.

Thanks for your feedback!
