### PR TITLE
add ability to replace a datasource

### DIFF
--- a/src/lib/control/typeahead/Typeahead.js
+++ b/src/lib/control/typeahead/Typeahead.js
@@ -122,6 +122,8 @@ JX.install('Typeahead', {
     _placeholder : null,
     _display : null,
     _datasource : null,
+    _waitingListener : null,
+    _readyListener : null,
 
     /**
      * Activate your properly configured typeahead. It won't do anything until
@@ -154,15 +156,19 @@ JX.install('Typeahead', {
      *                               draw from.
      */
     setDatasource : function(datasource) {
-      if (__DEV__) {
-        if (this._datasource) {
-          throw new Error(
-            "JX.Typeahead.setDatasource(): " +
-            "Typeahead already has a datasource.");
-        }
+      if (this._datasource) {
+        this._datasource.unbindFromTypeahead();
+        this._waitingListener.remove();
+        this._readyListener.remove();
       }
-      datasource.listen('waiting', JX.bind(this, this.waitForResults));
-      datasource.listen('resultsready', JX.bind(this, this.showResults));
+      this._waitingListener = datasource.listen(
+        'waiting',
+        JX.bind(this, this.waitForResults)
+      );
+      this._readyListener = datasource.listen(
+        'resultsready',
+        JX.bind(this, this.showResults)
+      );
       datasource.bindToTypeahead(this);
       this._datasource = datasource;
     },

--- a/src/lib/control/typeahead/source/TypeaheadSource.js
+++ b/src/lib/control/typeahead/source/TypeaheadSource.js
@@ -117,10 +117,23 @@ JX.install('TypeaheadSource', {
     _raw : null,
     _lookup : null,
     _excludeIDs : null,
+    _changeListener : null,
+    _startListener : null,
 
     bindToTypeahead : function(typeahead) {
-      typeahead.listen('change', JX.bind(this, this.didChange));
-      typeahead.listen('start', JX.bind(this, this.didStart));
+      this._changeListener = typeahead.listen(
+        'change',
+        JX.bind(this, this.didChange)
+      );
+      this._startListener = typeahead.listen(
+        'start',
+        JX.bind(this, this.didStart)
+      );
+    },
+
+    unbindFromTypeahead : function() {
+      this._changeListener.remove();
+      this._startListener.remove();
     },
 
     didChange : function(value) {


### PR DESCRIPTION
Summary: Adds the ability to swap the datasource of an existing typeahead for a new one

Test Plan: Successfully swapped an on-demand and a preloaded source back and forth within a tokenizer

Reviewers: epriestley

CC: aran, Korvin

Differential Revision: https://secure.phabricator.com/D3405
