### PR TITLE
Fix the issue that non-result node may be chosen.

### DIFF
--- a/src/lib/control/typeahead/Typeahead.js
+++ b/src/lib/control/typeahead/Typeahead.js
@@ -217,10 +217,14 @@ JX.install('Typeahead', {
     showResults : function(results) {
       var obj = {show: results};
       var e = this.invoke('show', obj);
-      this._display = obj.show;
+
+      // Note that the results list may have been update by the "show" event
+      // listener. Non-result node (e.g. divider or label) may have been
+      // inserted.
+      JX.DOM.setContent(this._root, results);
+      this._display = JX.DOM.scry(this._root, 'a', 'typeahead-result');
 
       if (this._display.length && !e.getPrevented()) {
-        JX.DOM.setContent(this._root, this._display);
         this._changeFocus(Number.NEGATIVE_INFINITY);
         var d = JX.Vector.getDim(this._hardpoint);
         d.x = 0;
@@ -231,6 +235,7 @@ JX.install('Typeahead', {
         JX.DOM.show(this._root);
       } else {
         this.hide();
+        JX.DOM.setContent(this._root, null);
       }
     },
 

--- a/src/lib/control/typeahead/Typeahead.js
+++ b/src/lib/control/typeahead/Typeahead.js
@@ -331,8 +331,11 @@ JX.install('Typeahead', {
      * @task control
      */
     submit : function() {
-      if (this._focus >= 0 && this._display[this._focus]) {
-        this._choose(this._display[this._focus]);
+      var result = this._focus >= 0 ?
+        JX.DOM.scry(this._root, 'a', 'typeahead-result')[this._focus] : 
+        null;
+      if (result) {
+        this._choose(result);
         return true;
       } else {
         result = this.invoke('query', this._control.value);

--- a/src/lib/control/typeahead/Typeahead.js
+++ b/src/lib/control/typeahead/Typeahead.js
@@ -331,11 +331,8 @@ JX.install('Typeahead', {
      * @task control
      */
     submit : function() {
-      var result = this._focus >= 0 ?
-        JX.DOM.scry(this._root, 'a', 'typeahead-result')[this._focus] : 
-        null;
-      if (result) {
-        this._choose(result);
+      if (this._focus >= 0 && this._display[this._focus]) {
+        this._choose(this._display[this._focus]);
         return true;
       } else {
         result = this.invoke('query', this._control.value);

--- a/src/lib/control/typeahead/Typeahead.js
+++ b/src/lib/control/typeahead/Typeahead.js
@@ -217,10 +217,14 @@ JX.install('Typeahead', {
     showResults : function(results) {
       var obj = {show: results};
       var e = this.invoke('show', obj);
-      this._display = obj.show;
+
+      // Note that the results list may have been update by the "show" event
+      // listener. None result node (e.g. divider or label) may have been
+      // inserted.
+      JX.DOM.setContent(this._root, results);
+      this._display = JX.DOM.scry(this._root, 'a', 'typeahead-result');
 
       if (this._display.length && !e.getPrevented()) {
-        JX.DOM.setContent(this._root, this._display);
         this._changeFocus(Number.NEGATIVE_INFINITY);
         var d = JX.Vector.getDim(this._hardpoint);
         d.x = 0;
@@ -231,6 +235,7 @@ JX.install('Typeahead', {
         JX.DOM.show(this._root);
       } else {
         this.hide();
+        JX.DOM.setContent(this._root, null);
       }
     },
 


### PR DESCRIPTION
When press ENTER to select an item, the result item should be queried lively, instead of beding read from this._display which may also contain non-result nodes.
