### PR TITLE
add an enable() method to Typeahead

### DIFF
--- a/src/lib/control/typeahead/Typeahead.js
+++ b/src/lib/control/typeahead/Typeahead.js
@@ -325,6 +325,15 @@ JX.install('Typeahead', {
     /**
      * @task control
      */
+    enable : function() {
+      this._control.disabled = false;
+      this._stop = false;
+    },
+
+
+    /**
+     * @task control
+     */
     disable : function() {
       this._control.blur();
       this._control.disabled = true;


### PR DESCRIPTION
Summary: adds an enable() method to Typeahead.  Use case is the following: I have a tokenizer and when a certain class of tokens is selected I want to disable the typeahead.  When those tokens are removed I want to re-enable the typeahead.

Test Plan: Implemented tokenizer with this behavior

Reviewers: epriestley

Reviewed By: epriestley

CC: aran, Korvin

Differential Revision: https://secure.phabricator.com/D3617
